### PR TITLE
Add udev rules file documenting device permission

### DIFF
--- a/contrib/udev-rules/70-pyrp360.rules
+++ b/contrib/udev-rules/70-pyrp360.rules
@@ -1,0 +1,2 @@
+# Digitech RP360/RP360XP Guitar Multi-Effect Floor Processor with USB Streaming
+ACTION=="add", SUBSYSTEM=="tty", ATTRS{idVendor}=="1210", ATTRS{idProduct}=="0032", TAG+="uaccess"

--- a/contrib/udev-rules/README.md
+++ b/contrib/udev-rules/README.md
@@ -1,0 +1,15 @@
+udev rules for Linux permission setup for the device files
+==========================================================
+
+On a modern Linux distribution, you can install the following file as
+`/etc/udev/rules.d/70-pyrp360.rules` so that the `/dev/ttyACM${N}`
+device for the RP360 or RP360XP is accessible from a non-priviledged
+user running pyrp360:
+
+```
+# Digitech RP360/RP360XP Guitar Multi-Effect Floor Processor with USB Streaming
+ACTION=="add", SUBSYSTEM=="tty", ATTRS{idVendor}=="1210", ATTRS{idProduct}=="0032", TAG+="uaccess"
+```
+
+If you want to use another access methods than `TAG+="uaccess"`, you
+can rewrite the above rule according rule.


### PR DESCRIPTION
Add an example udev rules file at `contrib/udev-rules/` as a convenience file or documentation regarding device permission setup.

When pyrp360 becomes more streamlined for OS packaging and system integration at some time in the future, the device permission setup will become a part of that.

Until then, having this documentation could be useful.

Closes: https://github.com/tschartz/pyrp360/issues/4